### PR TITLE
Allow commands to be run at entry time.

### DIFF
--- a/files/entry.sh
+++ b/files/entry.sh
@@ -5,7 +5,7 @@ if [ "${USER}" != "root" ]; then
     adduser --disabled-password --uid ${UID} --gecos ${USER} --home /code ${USER}
     echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER}
     echo "Defaults env_keep += \"SSH_AUTH_SOCK\"" >> /etc/sudoers.d/${USER}
-    sudo -E -i -u ${USER}
+    sudo -E -i -u ${USER} -- sh -c "${*}"
 else
-    sudo -E -i
+    sudo -E -i -- sh -c "${*}"
 fi


### PR DESCRIPTION
This enables the other changes in dsh script to work with the utility container to run commands using `docker run`.

This still gives you an interactive terminal when you don't supply any arguments. I.e. `./dsh shell`.